### PR TITLE
treeless clone for performance and space (Github only)

### DIFF
--- a/bin/buildsite.py
+++ b/bin/buildsite.py
@@ -57,7 +57,7 @@ def start_build(args):
     # Pull in repository data
     sourcepath = os.path.join(path, 'source')
     print("Cloning from git repository %s (branch: %s)" % (args.source, args.sourcebranch))
-    subprocess.run((GIT, 'clone', '--branch', args.sourcebranch, args.source, sourcepath),
+    subprocess.run((GIT, 'clone', '--branch', args.sourcebranch, '--filter=tree:0', args.source, sourcepath),
                    check=True)
 
     # Activate venv and install pips if needed. For dev/test, we will


### PR DESCRIPTION
I compared performance and disk space for treeless and blobless clones as described here:
https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

Treeless clones performed slightly better and could be smaller.

Note this DOES NOT do anything with gitbox.apache.org served repositories.

Github vs gitbox full clones are twice as fast from GitHub.
