### PR TITLE
Feature/allow empty plugins

### DIFF
--- a/bin/buildsite.py
+++ b/bin/buildsite.py
@@ -192,11 +192,16 @@ def generate_settings(source_yaml, settings_path, builtin_p_paths=[], sourcepath
     tdata = ydata['site']  # Easy to copy these simple values.
     tdata.update({
         'year': datetime.date.today().year,
-        'p_paths': builtin_p_paths + [ os.path.join(sourcepath, p) for p in ydata['plugins']['paths'] ],
-        'use': ydata['plugins']['use'],
         'theme': os.path.join(sourcepath, ydata.get('theme', 'theme/apache')),
         'debug': str(ydata.get('debug', False)),
         })
+    tdata['p_paths'] = builtin_p_paths
+    tdata['use'] = ['gfm']
+    if 'plugins' in ydata:
+        if 'paths' in ydata['plugins']:
+            tdata['p_paths'].append([ os.path.join(sourcepath, p) for p in ydata['plugins']['paths'] ])
+        if 'use' in ydata['plugins']:
+            tdata['use'] = ydata['plugins']['use'],
 
     if 'genid' in ydata:
         class GenIdParams:

--- a/bin/buildsite.py
+++ b/bin/buildsite.py
@@ -199,9 +199,10 @@ def generate_settings(source_yaml, settings_path, builtin_p_paths=[], sourcepath
     tdata['use'] = ['gfm']
     if 'plugins' in ydata:
         if 'paths' in ydata['plugins']:
-            tdata['p_paths'].append([ os.path.join(sourcepath, p) for p in ydata['plugins']['paths'] ])
+            for p in ydata['plugins']['paths']:
+                tdata['p_paths'].append(os.path.join(sourcepath, p))
         if 'use' in ydata['plugins']:
-            tdata['use'] = ydata['plugins']['use'],
+            tdata['use'] = ydata['plugins']['use']
 
     if 'genid' in ydata:
         class GenIdParams:


### PR DESCRIPTION
In most cases websites will only use the standard plugins directory and won't need to have an empty directory in the site repository. While that can be ok with pelican as it probably will never look in the secondary plugin directory. Once we go into a mode where the repository's plugins may override the standard then there is a problem.

In addition to:
```
plugins:
  paths:
    - theme/plugins
  use:
    - gfm
```

The following forms are possible:
1. empty / default
   ```
   ```
2. only `use`
   ```
   plugins:
     use:
       - gfm
   ```
3. only `paths`
    ```
   plugins:
     paths:
       - theme/plugins
   ```

If `use` is missing then `gfm` is always used.
If `paths` is missing then only the `builtin_paths` are used.