### PR TITLE
Restrict jinja2 version to 3.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ RUN apt install subversion -y
 
 ARG PELICAN_VERSION=4.6.0
 ARG MATPLOTLIB_VERSION=3.4.1
+# Workaround for https://github.com/apache/infrastructure-pelican/issues/29
+# to make sure we install versions of jinja and pelican that don't conflict.
+# Installing jinja explicitly can be removed once we upgrade to pelican
+# 4.7.0 or later
+RUN pip install jinja2==3.0.3
 RUN pip install pelican==${PELICAN_VERSION}
 RUN pip install matplotlib==${MATPLOTLIB_VERSION}
 


### PR DESCRIPTION
This is the most conservative change that fixes #29: because pelican 4.6.0 specifies `jinja2>=2.7`, but jinja2 versions of 3.1.0 or later conflict with
pelican 4.6.0, this leads to a broken environment.

This conflict is fixed on pelican 4.7.0 or later,
so when pelican is upgraded this workaround can be removed, but updating pelican might need further testing.