### PR TITLE
Extend where matching: eq, ne, in and not in

### DIFF
--- a/.github/workflows/where.yml
+++ b/.github/workflows/where.yml
@@ -1,0 +1,34 @@
+name: Unit test where conditions
+on:
+  workflow_dispatch:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        # Not sure it's worth testing on multiple Pythons
+        python-version: [3.8]
+    steps:
+    - uses: actions/checkout@master
+      with:
+        persist-credentials: false
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pelican[Markdown]==4.5.4
+        pip install -r requirements.txt
+        pip install 'MarkupSafe<2.1.0' # needed for Pelican 4.5.4
+    - name: Run test
+      run: |
+        cd tests/where
+        PYTHONPATH="../.." python testasfdata.py

--- a/plugins/asfdata.py
+++ b/plugins/asfdata.py
@@ -99,14 +99,52 @@ def remove_part(reference, part):
             remove_part(reference[refs], part)
 
 
-# trim out parts of a data source that don't match part = True
-def where_parts(reference, part):
+# does the part match the where clause?
+# This can be:
+#   where: key
+# In this case, the key lookup value must be True
+# or:
+#   where: key eq|ne|in value(s)
+# The key lookup value must equal or not equal the value, or
+# must be one of the space-separated values (respectively)
+def partMatches(actual, cond, expected):
+    if cond is None and expected is None:
+        return actual # Is it True?
+    if cond == 'eq':
+        return actual == expected
+    if cond == 'ne':
+        return actual != expected
+    if cond == 'in':
+        return actual in expected
+    if cond == 'notin':
+        return actual not in expected
+    raise Exception(f"Unexpected condition {cond}")
+
+# trim out parts of a data source that don't match the part condition (default == True)
+def where_parts(reference, where_clause):
+    items = where_clause.split()
+    key = items.pop(0)
+    if len(items) == 0:
+        cond = None
+        expected = None
+    elif len(items) >= 2:
+        cond = items.pop(0)
+        if cond in ['ne', 'eq'] and len(items) == 1: # should only be one item left
+            expected = items.pop(0)
+        elif cond in ['in', 'notin']:
+            expected = items
+        else:
+            # TODO: choose better exception
+            raise Exception(f"Unexpected condition '{cond}' or extra param: {len(items)}")
+    else:
+        # TODO: choose better exception
+        raise Exception(f"where expects 1 parameter optionally followed by at least 2 parameters") # pylint: disable=broad-exception-raised
     # currently only works on True parts
     # if we trim as we go we invalidate the iterator. Instead create a deletion list.
     filtered = [ ]
     # first find the list that needs to be trimmed.
     for refs in reference:
-        if not reference[refs][part]:
+        if not partMatches(reference[refs][key], cond, expected):
             filtered.append(refs)
     # remove the parts to be trimmed.
     for refs in filtered:

--- a/plugins/asfdata.py
+++ b/plugins/asfdata.py
@@ -104,9 +104,9 @@ def remove_part(reference, part):
 #   where: key
 # In this case, the key lookup value must be True
 # or:
-#   where: key eq|ne|in value(s)
+#   where: key eq|ne|in|notin value(s)
 # The key lookup value must equal or not equal the value, or
-# must be one of the space-separated values (respectively)
+# must be (not) one of the space-separated values (respectively)
 def partMatches(actual, cond, expected):
     if cond is None and expected is None:
         return actual # Is it True?
@@ -198,7 +198,7 @@ def add_logo(reference, part):
 def sequence_dict(seq, reference):
     sequence = [ ]
     for refs in reference:
-        # converting dicts into objects with attrributes. Ignore non-dict content.
+        # converting dicts into objects with attributes. Ignore non-dict content.
         if isinstance(reference[refs], dict):
             # put the key of the dict  into the dictionary
             reference[refs]['key_id'] = refs
@@ -458,7 +458,7 @@ def process_distributions(project, src, sort_revision, debug):
                 fsize = listing[-6]
             # date is close enough
             dtm = dtm1.strftime("%m/%d/%Y")
-            # covert to number of MB
+            # convert to number of MB
             if float(fsize) > 524288:
                 fsize = ('%.2f' % bytesto(fsize, 'm')) + ' MB'
             else:

--- a/plugins/asfdata.py
+++ b/plugins/asfdata.py
@@ -118,7 +118,7 @@ def partMatches(actual, cond, expected):
         return actual in expected
     if cond == 'notin':
         return actual not in expected
-    raise Exception(f"Unexpected condition {cond}")
+    raise Exception(f"Unexpected condition {cond}") # pylint: disable=broad-exception-raised
 
 # trim out parts of a data source that don't match the part condition (default == True)
 def where_parts(reference, where_clause):
@@ -135,10 +135,10 @@ def where_parts(reference, where_clause):
             expected = items
         else:
             # TODO: choose better exception
-            raise Exception(f"Unexpected condition '{cond}' or extra param: {len(items)}")
+            raise Exception(f"Unexpected condition '{cond}' or extra param: {len(items)}")  # pylint: disable=broad-exception-raised
     else:
         # TODO: choose better exception
-        raise Exception(f"where expects 1 parameter optionally followed by at least 2 parameters") # pylint: disable=broad-exception-raised
+        raise Exception("'where' expects 1 parameter optionally followed by at least 2 parameters") # pylint: disable=broad-exception-raised
     # currently only works on True parts
     # if we trim as we go we invalidate the iterator. Instead create a deletion list.
     filtered = [ ]

--- a/tests/where/asfdatawhere.yaml
+++ b/tests/where/asfdatawhere.yaml
@@ -1,0 +1,47 @@
+pods1:
+  url: https://whimsy.apache.org/public/public_podlings.json
+  current_count:
+    path: status_counts.current
+  current:
+    path: podling
+    where: status eq current
+pods2:
+  url: https://whimsy.apache.org/public/public_podlings.json
+  graduated_count:
+    path: status_counts.graduated
+  graduated:
+    path: podling
+    where: status eq graduated
+pods3:
+  url: https://whimsy.apache.org/public/public_podlings.json
+  retired_count:
+    path: status_counts.retired
+  retired:
+    path: podling
+    where: status eq retired
+pods4:
+  url: https://whimsy.apache.org/public/public_podlings.json
+  notretired:
+    path: podling
+    where: status ne retired
+pods5:
+  url: https://whimsy.apache.org/public/public_podlings.json
+  inretiredgraduated:
+    path: podling
+    where: status in retired graduated
+pods5:
+  url: https://whimsy.apache.org/public/public_podlings.json
+  notinretiredgraduated:
+    path: podling
+    where: status notin retired graduated
+ci:
+  url: https://whimsy.apache.org/public/committee-info.json
+  cttee_count:
+    path: committee_count
+  pmc_count:
+    path: pmc_count
+  cttee:
+    path: committees
+  pmc:
+    path: committees
+    where: pmc

--- a/tests/where/testasfdata.py
+++ b/tests/where/testasfdata.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import pelican
+import plugins.asfdata as asfdata
+
+settings = { # Keep pelican happy
+    'MARKDOWN': {},
+    'FORMATTED_FIELDS': [],
+    'PATH': '.',
+    'OUTPUT_PATH': 'output',
+    'THEME': 'simple',
+    'IGNORE_FILES': [],
+    'DELETE_OUTPUT_DIRECTORY': False,
+    'OUTPUT_RETENTION': 0,
+    'ASF_DATA': {
+        'data': 'TBA',
+        'metadata': {
+        },
+        'debug': False,
+    }
+}
+
+def test(name):
+    settings['ASF_DATA']['data'] = f"{name}.yaml"
+    settings['ASF_DATA']['metadata'] = {}
+    pc = pelican.Pelican(settings)
+    asfdata.config_read_data(pc)
+    metadata = settings['ASF_DATA']['metadata']
+    assert metadata['current_count'] == metadata['current_size']
+    assert metadata['graduated_count'] == metadata['graduated_size']
+    assert metadata['retired_count'] == metadata['retired_size']
+    assert metadata['notretired_size'] == metadata['graduated_size'] + metadata['current_size']
+    assert metadata['notinretiredgraduated_size'] == metadata['current_size']
+    assert metadata['cttee_count'] == metadata['cttee_size']
+    assert metadata['pmc_count'] == metadata['pmc_size']
+
+test('asfdatawhere')


### PR DESCRIPTION
Current where matching is very limited.
This extends the conditions to allow for more filtering.
For example, can now extract graduated podlings from https://whimsy.apache.org/public/public_podlings.json.