### PR TITLE
Don't mangle name if it does not match expected format

### DIFF
--- a/plugins/asfdata.py
+++ b/plugins/asfdata.py
@@ -352,7 +352,7 @@ def process_sequence(metadata, seq, sequence, load, debug):
                 # for podlings strip "Apache" from the beginning and "(incubating)" from the end.
                 # this is Sally's request
                 for item in reference:
-                    setattr(item, 'name', ' '.join(item.name.split(' ')[1:-1]))
+                    setattr(item, 'name', item.name.replace('Apache ', '').replace(' (incubating)', ''))
         else:
             print(f'{seq} - logo requires an existing sequence')
 


### PR DESCRIPTION
The code that removes 'Apache ' and ' (incubating)' assumes that these are both present.
If not, then the name can end up as an empty string.