### PR TITLE
Handle GFM metadata keyword variants

### DIFF
--- a/plugins/gfm.py
+++ b/plugins/gfm.py
@@ -136,7 +136,34 @@ class GFMReader(pelican.readers.BaseReader):
     # Note: name starts in column 0, no whitespace before colon, will be
     #       made lower-case, and value will be stripped
     #
-    RE_METADATA = re.compile('^([A-za-z]+): (.*)$')
+    RE_METADATA = re.compile(r'^([A-Za-z0-9_-]+):[ \t]*(.*)$')
+
+    @classmethod
+    def _split_metadata(cls, text, metadata):
+        lines = text.splitlines()
+        content_start = len(lines)
+
+        for i in range(len(lines)):
+            line = lines[i]
+            match = cls.RE_METADATA.match(line)
+            if match:
+                name = match.group(1).strip().lower()
+                if name != 'slug':
+                    value = match.group(2).strip()
+                    if name == 'date':
+                        value = pelican.utils.get_date(value)
+                    metadata[name] = value
+                #if name != 'title':
+                #  print 'META:', name, value
+            elif not line.strip():
+                # blank line
+                continue
+            else:
+                # reached actual content
+                content_start = i
+                break
+
+        return '\n'.join(lines[content_start:]), metadata
 
     def read_source(self, source_path):
         "Read metadata and content from the source."
@@ -156,26 +183,7 @@ class GFMReader(pelican.readers.BaseReader):
         with pelican.utils.pelican_open(source_path) as text:
 
             # Extract the metadata from the header of the text
-            lines = text.splitlines()
-            i = 0 # See https://github.com/apache/infrastructure-pelican/issues/70
-            for i in range(len(lines)):
-                line = lines[i]
-                match = GFMReader.RE_METADATA.match(line)
-                if match:
-                    name = match.group(1).strip().lower()
-                    if name != 'slug':
-                        value = match.group(2).strip()
-                        if name == 'date':
-                            value = pelican.utils.get_date(value)
-                    metadata[name] = value
-                    #if name != 'title':
-                    #  print 'META:', name, value
-                elif not line.strip():
-                    # blank line
-                    continue
-                else:
-                    # reached actual content
-                    break
+            text, metadata = GFMReader._split_metadata(text, metadata)
 
             # Redo the slug for articles.
             # depending on pelicanconf.py this will change the output filename
@@ -183,10 +191,6 @@ class GFMReader(pelican.readers.BaseReader):
                 metadata['slug'] = pelican.utils.slugify(
                     metadata['title'],
                     self.settings.get('SLUG_SUBSTITUTIONS', ()))
-
-            # Reassemble content, minus the metadata
-            text = '\n'.join(lines[i:])
-
             return text, metadata
 
     def read(self, source_path):

--- a/tests/test_gfm_metadata.py
+++ b/tests/test_gfm_metadata.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import importlib
+import sys
+import types
+
+
+class FakeFunc:
+    def __call__(self, *args):
+        return 1
+
+
+class FakeCmark:
+    def __getattr__(self, _name):
+        return FakeFunc()
+
+
+def load_gfm(monkeypatch):
+    monkeypatch.setenv('LIBCMARKDIR', '.')
+    monkeypatch.setattr('ctypes.CDLL', lambda *_args: FakeCmark())
+
+    pelican = types.ModuleType('pelican')
+    utils = types.ModuleType('pelican.utils')
+    plugins = types.ModuleType('pelican.plugins')
+    signals = types.ModuleType('pelican.plugins.signals')
+    readers = types.ModuleType('pelican.readers')
+
+    class BaseReader:
+        pass
+
+    class Signal:
+        def connect(self, _func):
+            pass
+
+    utils.get_date = lambda value: value
+    readers.BaseReader = BaseReader
+    signals.readers_init = Signal()
+    plugins.signals = signals
+    pelican.utils = utils
+    pelican.plugins = plugins
+    pelican.readers = readers
+
+    monkeypatch.setitem(sys.modules, 'pelican', pelican)
+    monkeypatch.setitem(sys.modules, 'pelican.utils', utils)
+    monkeypatch.setitem(sys.modules, 'pelican.plugins', plugins)
+    monkeypatch.setitem(sys.modules, 'pelican.plugins.signals', signals)
+    monkeypatch.setitem(sys.modules, 'pelican.readers', readers)
+    sys.modules.pop('plugins.gfm', None)
+
+    return importlib.import_module('plugins.gfm')
+
+
+def test_metadata_keys_allow_python_markdown_characters(monkeypatch):
+    gfm = load_gfm(monkeypatch)
+
+    text, metadata = gfm.GFMReader._split_metadata(
+        'Title2: Example\n'
+        'jira_key: INFRA-1\n'
+        'page-kind: docs\n'
+        '\n'
+        'Body',
+        {},
+    )
+
+    assert text == 'Body'
+    assert metadata == {
+        'title2': 'Example',
+        'jira_key': 'INFRA-1',
+        'page-kind': 'docs',
+    }
+
+
+def test_final_metadata_line_without_eol_is_not_body(monkeypatch):
+    gfm = load_gfm(monkeypatch)
+
+    text, metadata = gfm.GFMReader._split_metadata('Title: Metadata only', {})
+
+    assert text == ''
+    assert metadata == {'title': 'Metadata only'}


### PR DESCRIPTION
Fixes #66.
Also fixes #72.

Checks:
- uv run --with pytest python -m pytest tests/test_gfm_metadata.py -q
- uv run python -m py_compile plugins/gfm.py tests/test_gfm_metadata.py
- git diff --check